### PR TITLE
jslint fixes including removed unused internal makeID function, avoid…

### DIFF
--- a/src/indexeddb-js.js
+++ b/src/indexeddb-js.js
@@ -180,6 +180,76 @@ define(['underscore'], function(_) { 'use strict';
   };
 
   //---------------------------------------------------------------------------
+  var Cursor = function(source, range, direction, retkey, request) {
+
+    this.source      = source;
+    this.direction   = direction || 'next';
+    // todo: implement these attributes...
+    // this.primaryKey  = ...;
+
+    if ( range && ! ( range instanceof IDBKeyRange ) ) {
+      range = IDBKeyRange.only(range);
+    }
+
+    // -- private attributes
+    this._range    = range;
+    this._request  = request;
+    this._data     = null;
+    this._next     = 0;
+    this._retkey   = retkey;
+    this._error    = function(event) {
+      if ( this.onerror ) {
+        this.onerror(event);
+      }
+      if ( ! event._preventDefault ) {
+        this.source._error(event);
+      }
+    };
+
+    //-------------------------------------------------------------------------
+    this['continue'] = function() {
+      defer(function() {
+        if ( this.direction !== 'next' ) {
+          return this._request._error(this, 'indexeddb.Cursor.C.5',
+                                      'non-"next" cursor direction not supported');
+        }
+        if ( this._data == undefined ) {
+          return this.source._getAll(this._request, this._range, function(err, rows) {
+            if ( err ) {
+              return this._request._error(this, 'indexeddb.Cursor.C.10',
+                                          'failed to fetch data for cursor: ' + err);
+            }
+            this._data = rows;
+            this._next = 0;
+            this['continue']();
+          }, this);
+        }
+        if ( this._next >= this._data.length )
+        {
+          if ( this._request.onsuccess ) {
+            this._request.onsuccess(new Event({result: null}));
+          }
+          return;
+        }
+        this.key      = this._data[this._next].key;
+        this.value    = this._data[this._next].value;
+        this.position = this._next;
+        this._next    += 1;
+        if ( this._request.onsuccess ) {
+          this._request.onsuccess(new Event({result: this}));
+        }
+        return;
+      }, this);
+    };
+
+    // todo: implement
+    // this.update = function() {};
+    // this.advance = function() {};
+    // this.delete = function() {};
+
+  };
+
+  //---------------------------------------------------------------------------
   var Index = function(store, name) {
     // TODO: implement these attributes...
     // this.keyPath = ...;
@@ -292,77 +362,6 @@ define(['underscore'], function(_) { 'use strict';
 
     return this;
   };
-
-  //---------------------------------------------------------------------------
-  var Cursor = function(source, range, direction, retkey, request) {
-
-    this.source      = source;
-    this.direction   = direction || 'next';
-    // todo: implement these attributes...
-    // this.primaryKey  = ...;
-
-    if ( range && ! ( range instanceof IDBKeyRange ) ) {
-      range = IDBKeyRange.only(range);
-    }
-
-    // -- private attributes
-    this._range    = range;
-    this._request  = request;
-    this._data     = null;
-    this._next     = 0;
-    this._retkey   = retkey;
-    this._error    = function(event) {
-      if ( this.onerror ) {
-        this.onerror(event);
-      }
-      if ( ! event._preventDefault ) {
-        this.source._error(event);
-      }
-    };
-
-    //-------------------------------------------------------------------------
-    this['continue'] = function() {
-      defer(function() {
-        if ( this.direction !== 'next' ) {
-          return this._request._error(this, 'indexeddb.Cursor.C.5',
-                                      'non-"next" cursor direction not supported');
-        }
-        if ( this._data == undefined ) {
-          return this.source._getAll(this._request, this._range, function(err, rows) {
-            if ( err ) {
-              return this._request._error(this, 'indexeddb.Cursor.C.10',
-                                          'failed to fetch data for cursor: ' + err);
-            }
-            this._data = rows;
-            this._next = 0;
-            this['continue']();
-          }, this);
-        }
-        if ( this._next >= this._data.length )
-        {
-          if ( this._request.onsuccess ) {
-            this._request.onsuccess(new Event({result: null}));
-          }
-          return;
-        }
-        this.key      = this._data[this._next].key;
-        this.value    = this._data[this._next].value;
-        this.position = this._next;
-        this._next    += 1;
-        if ( this._request.onsuccess ) {
-          this._request.onsuccess(new Event({result: this}));
-        }
-        return;
-      }, this);
-    };
-
-    // todo: implement
-    // this.update = function() {};
-    // this.advance = function() {};
-    // this.delete = function() {};
-
-  };
-
 
   //---------------------------------------------------------------------------
   var Store = function(txn, name, options, create) {


### PR DESCRIPTION
…ed setting accidental "err" and "self" globals, avoided mistaken use of "req" where only "request" was available, avoided mistaken use of (undefined) "self" in req._error call, avoided adding the drop table callback in loop where its datatable value in error reporting would be mistaken, and also added comment around apparently problematic section checking for "this.changes" and "diff.changes" which don't seem to be set elsewhere in script.

I'm kind of stubborn in relying on jslint, so if you don't want the other jslint-based changes, I'm afraid I'll just need to go on with my own fork (though feel free to pick through to find the more crucial errors mentioned above). I'd be particularly interested to know what the "diff.changes"/"this.changes" code was about and whether it can just be removed since it seems it will only throw an error.
