### PR TITLE
Fixes and oldVersion on onupgradeneeded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name":           "indexeddb-js",
   "description":    "A pure javascript stop-gap implementation of the IndexedDB (aka. Indexed Database) API using sqlite3 as a storage engine.",
-  "version":        "0.0.14",
+  "version":        "0.0.15",
   "main":           "src/indexeddb-js.js",
   "author":         "metagriffin <mg.npmjs@uberdev.org>",
   "contributors":   ["Brett Zamir <brettz9@yahoo.com>"],

--- a/src/indexeddb-js.js
+++ b/src/indexeddb-js.js
@@ -944,7 +944,7 @@ define(['underscore'], function(_) {
 
     this.vendor  = 'indexeddb-js';
     // TODO: pull this dynamically from package.json somehow?...
-    this.version = '0.0.14';
+    this.version = '0.0.15';
 
     //-------------------------------------------------------------------------
     this.open = function(name, version) {

--- a/src/indexeddb-js.js
+++ b/src/indexeddb-js.js
@@ -915,10 +915,11 @@ define(['underscore'], function(_) {
     //-------------------------------------------------------------------------
     this.setVersion = function(version) {
       var req = new Request();
-        defer(function(){req._error(this, 'indexeddb.Database.SV.10',
-                                    'setVersion() has been deprecated in favor of onupgradeneeded');}, this);
-        return req;
-      };
+      defer(function(){
+        req._error(this, 'indexeddb.Database.SV.10',
+          'setVersion() has been deprecated in favor of onupgradeneeded');
+        }, this);
+      return req;
     };
 
     //-------------------------------------------------------------------------

--- a/src/indexeddb-js.js
+++ b/src/indexeddb-js.js
@@ -765,11 +765,9 @@ define(['underscore'], function(_) {
                         return request._error(
                           null, 'indexeddb.Database.iL.26',
                           'could not update database version: ' + err);
-                      return self._upgrade(request);
+                      return self._upgrade(request, {oldVersion: cur});
                     });
-
                 });
-
               return;
             }
             self.version = self.version || 1;
@@ -788,11 +786,14 @@ define(['underscore'], function(_) {
     };
 
     //-------------------------------------------------------------------------
-    this._upgrade = function(request) {
+    this._upgrade = function(request, options) {
+      var options = options || {};
       var self = this;
       var ret = new Event(request);
       ret.target.transaction = new Transaction(this, [], 'readwrite');
       ret.target.transaction.mode = 'versionchange';
+      if(options.oldVersion)
+        ret.oldVersion = options.oldVersion;
       this._upgrading = [];
       if ( request.onupgradeneeded )
         request.onupgradeneeded(ret);

--- a/test/test-indexeddb-js.spec.js
+++ b/test/test-indexeddb-js.spec.js
@@ -170,6 +170,7 @@ define([
         req2.onerror = makeErrorHandler('reuse', 'open2.error', done);
         req2.onupgradeneeded = function(event) {
           var db = event.target.result;
+          expect(event.oldVersion).toEqual(1);
           expect(db.version).toEqual(7);
           expect(event.target.transaction.mode).toEqual('versionchange');
         };


### PR DESCRIPTION
1.Some fixes;
2.The `event` argument sent on `onupgradeneeded` now has `oldVersion` useful to partial database update - tested.